### PR TITLE
CSD-4932 - Redesign match handling to avoid XSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 bower_components
 .*.swp
 .DS_Store
+.idea/
+.vscode/

--- a/.jshintrc
+++ b/.jshintrc
@@ -8,7 +8,7 @@
   "eqeqeq": true,
   "immed": true,
   "indent": 2,
-  "latedef": true,
+  "latedef": false,
   "newcap": true,
   "noarg": true,
   "quotmark": "single",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,8 +20,7 @@ module.exports = function (grunt) {
     },
     karma: {
       options: {
-        configFile: 'test/karma.conf.js',
-        browsers: ['PhantomJS']
+        configFile: 'test/karma.conf.js'
       },
       unit: {
         singleRun: true

--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -214,23 +214,44 @@
       }
 
       function findMatchString(target, str) {
-        var result, matches, re;
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
         // Escape user input to be treated as a literal string within a regular expression
-        re = new RegExp(str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+        var re = new RegExp(str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
         if (!target) {
           return;
         }
         if (!target.match || !target.replace) {
           target = target.toString();
         }
-        matches = target.match(re);
-        if (matches) {
-          result = target.replace(re,
-            '<span class="' + scope.matchClass + '">' + matches[0] + '</span>');
-        } else {
-          result = target;
+
+        // Get the first match of the search string
+        // TODO investigate polyfill for matchAll so we can highlight all the matches
+        var match = target.match(re);
+
+        // If there are no matches, we can just use the target string
+        if (!match || !match[0]) {
+          return [{string: target, match: false}];
         }
+
+        var result = [];
+
+        // Account for a possible unmatched region between start of string and the first match
+        if (match.index > 0) {
+          result.push({string: target.substring(0, match.index), match: false});
+        }
+
+        // Add every result to the matches array tagged as a match
+        var matchedRegion = match[0];
+
+        result.push({string: matchedRegion, match: true});
+
+        // Account for a region between this match and the end of the string
+        var unmatchedRegion = target.substring(match.index + matchedRegion.length, target.length);
+
+        if (unmatchedRegion.length > 0) {
+          result.push({string: unmatchedRegion, match: false});
+        }
+
         return result;
       }
 

--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -7,7 +7,7 @@
 
 /*! Copyright (c) 2014 Hidenari Nozaki and contributors | Licensed under the MIT license */
 
-(function (root, factory) {
+(function(root, factory) {
   'use strict';
   if (typeof module !== 'undefined' && module.exports) {
     // CommonJS
@@ -19,18 +19,20 @@
     // Global Variables
     factory(root.angular);
   }
-}(window, function (angular) {
+}(window, function(angular) {
   'use strict';
 
-  angular.module('angucomplete-alt', []).directive('angucompleteAlt', ['$q', '$parse', '$http', '$sce', '$timeout', '$templateCache', '$interpolate', function ($q, $parse, $http, $sce, $timeout, $templateCache, $interpolate) {
+  angular.module('angucomplete-alt', []);
+
+  angular.module('angucomplete-alt').directive('angucompleteAlt', ['$q', '$parse', '$http', '$sce', '$timeout', '$templateCache', '$interpolate', function($q, $parse, $http, $sce, $timeout, $templateCache, $interpolate) {
     // keyboard events
-    var KEY_DW  = 40;
-    var KEY_RT  = 39;
-    var KEY_UP  = 38;
-    var KEY_LF  = 37;
-    var KEY_ES  = 27;
-    var KEY_EN  = 13;
-    var KEY_TAB =  9;
+    var KEY_DW = 40;
+    var KEY_RT = 39;
+    var KEY_UP = 38;
+    var KEY_LF = 37;
+    var KEY_ES = 27;
+    var KEY_EN = 13;
+    var KEY_TAB = 9;
 
     var MIN_LENGTH = 3;
     var MAX_LENGTH = 524288;  // the default max length per the html maxlength attribute
@@ -45,23 +47,23 @@
 
     // Set the default template for this directive
     $templateCache.put(TEMPLATE_URL,
-        '<div class="angucomplete-holder" ng-class="{\'angucomplete-dropdown-visible\': showDropdown}">' +
-        '  <input id="{{id}}_value" name="{{inputName}}" tabindex="{{fieldTabindex}}" ng-class="{\'angucomplete-input-not-empty\': notEmpty}" ng-model="searchStr" ng-disabled="disableInput" type="{{inputType}}" placeholder="{{placeholder}}" maxlength="{{maxlength}}" ng-focus="onFocusHandler()" class="{{inputClass}}" ng-focus="resetHideResults()" ng-blur="hideResults($event)" autocapitalize="off" autocorrect="off" autocomplete="off" ng-change="inputChangeHandler(searchStr)"/>' +
-        '  <div id="{{id}}_dropdown" class="angucomplete-dropdown" ng-show="showDropdown">' +
-        '    <div class="angucomplete-searching" ng-show="searching" ng-bind="textSearching"></div>' +
-        '    <div class="angucomplete-searching" ng-show="!searching && (!results || results.length == 0)" ng-bind="textNoResults"></div>' +
-        '    <div class="angucomplete-row" ng-repeat="result in results" ng-click="selectResult(result)" ng-mouseenter="hoverRow($index)" ng-class="{\'angucomplete-selected-row\': $index == currentIndex}">' +
-        '      <div ng-if="imageField" class="angucomplete-image-holder">' +
-        '        <img ng-if="result.image && result.image != \'\'" ng-src="{{result.image}}" class="angucomplete-image"/>' +
-        '        <div ng-if="!result.image && result.image != \'\'" class="angucomplete-image-default"></div>' +
-        '      </div>' +
-        '      <div class="angucomplete-title" ng-if="matchClass" ng-bind-html="result.title"></div>' +
-        '      <div class="angucomplete-title" ng-if="!matchClass">{{ result.title }}</div>' +
-        '      <div ng-if="matchClass && result.description && result.description != \'\'" class="angucomplete-description" ng-bind-html="result.description"></div>' +
-        '      <div ng-if="!matchClass && result.description && result.description != \'\'" class="angucomplete-description">{{result.description}}</div>' +
-        '    </div>' +
-        '  </div>' +
-        '</div>'
+      '<div class="angucomplete-holder" ng-class="{\'angucomplete-dropdown-visible\': showDropdown}">' +
+      '  <input id="{{id}}_value" name="{{inputName}}" tabindex="{{fieldTabindex}}" ng-class="{\'angucomplete-input-not-empty\': notEmpty}" ng-model="searchStr" ng-disabled="disableInput" type="{{inputType}}" placeholder="{{placeholder}}" maxlength="{{maxlength}}" ng-focus="onFocusHandler()" class="{{inputClass}}" ng-focus="resetHideResults()" ng-blur="hideResults($event)" autocapitalize="off" autocorrect="off" autocomplete="off" ng-change="inputChangeHandler(searchStr)"/>' +
+      '  <div id="{{id}}_dropdown" class="angucomplete-dropdown" ng-show="showDropdown">' +
+      '    <div class="angucomplete-searching" ng-show="searching" ng-bind="textSearching"></div>' +
+      '    <div class="angucomplete-searching" ng-show="!searching && (!results || results.length == 0)" ng-bind="textNoResults"></div>' +
+      '    <div class="angucomplete-row" ng-repeat="result in results" ng-click="selectResult(result)" ng-mouseenter="hoverRow($index)" ng-class="{\'angucomplete-selected-row\': $index == currentIndex}">' +
+      '      <div ng-if="imageField" class="angucomplete-image-holder">' +
+      '        <img ng-if="result.image && result.image != \'\'" ng-src="{{result.image}}" class="angucomplete-image"/>' +
+      '        <div ng-if="!result.image && result.image != \'\'" class="angucomplete-image-default"></div>' +
+      '      </div>' +
+      '      <div class="angucomplete-title" ng-if="matchClass" ng-bind-html="result.title"></div>' +
+      '      <div class="angucomplete-title" ng-if="!matchClass">{{ result.title }}</div>' +
+      '      <div ng-if="matchClass && result.description && result.description != \'\'" class="angucomplete-description" ng-bind-html="result.description"></div>' +
+      '      <div ng-if="!matchClass && result.description && result.description != \'\'" class="angucomplete-description">{{result.description}}</div>' +
+      '    </div>' +
+      '  </div>' +
+      '</div>'
     );
 
     function link(scope, elem, attrs, ctrl) {
@@ -87,8 +89,7 @@
           if (mousedownOn === scope.id + '_dropdown') {
             document.body.addEventListener('click', clickoutHandlerForDropdown);
           }
-        }
-        else {
+        } else {
           mousedownOn = event.target.className;
         }
       });
@@ -108,17 +109,15 @@
         if (newval !== oldval) {
           if (!newval) {
             ctrl[scope.inputName].$setValidity(requiredClassName, true);
-          }
-          else if (!validState || scope.currentIndex === -1) {
+          } else if (!validState || scope.currentIndex === -1) {
             handleRequired(false);
-          }
-          else {
+          } else {
             handleRequired(true);
           }
         }
       });
 
-      scope.$on('angucomplete-alt:clearInput', function (event, elementId) {
+      scope.$on('angucomplete-alt:clearInput', function(event, elementId) {
         if (!elementId || elementId === scope.id) {
           scope.searchStr = null;
           callOrAssign();
@@ -127,7 +126,7 @@
         }
       });
 
-      scope.$on('angucomplete-alt:changeInput', function (event, elementId, newval) {
+      scope.$on('angucomplete-alt:changeInput', function(event, elementId, newval) {
         if (!!elementId && elementId === scope.id) {
           handleInputChange(newval);
         }
@@ -165,15 +164,13 @@
       function callOrAssign(value) {
         if (typeof scope.selectedObject === 'function') {
           scope.selectedObject(value, scope.selectedObjectData);
-        }
-        else {
+        } else {
           scope.selectedObject = value;
         }
 
         if (value) {
           handleRequired(true);
-        }
-        else {
+        } else {
           handleRequired(false);
         }
       }
@@ -205,13 +202,12 @@
       function extractValue(obj, key) {
         var keys, result;
         if (key) {
-          keys= key.split('.');
+          keys = key.split('.');
           result = obj;
           for (var i = 0; i < keys.length; i++) {
             result = result[keys[i]];
           }
-        }
-        else {
+        } else {
           result = obj;
         }
         return result;
@@ -222,17 +218,20 @@
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
         // Escape user input to be treated as a literal string within a regular expression
         re = new RegExp(str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
-        if (!target) { return; }
-        if (!target.match || !target.replace) { target = target.toString(); }
+        if (!target) {
+          return;
+        }
+        if (!target.match || !target.replace) {
+          target = target.toString();
+        }
         matches = target.match(re);
         if (matches) {
           result = target.replace(re,
-              '<span class="'+ scope.matchClass +'">'+ matches[0] +'</span>');
-        }
-        else {
+            '<span class="' + scope.matchClass + '">' + matches[0] + '</span>');
+        } else {
           result = target;
         }
-        return $sce.trustAsHtml(result);
+        return result;
       }
 
       function handleRequired(valid) {
@@ -252,22 +251,19 @@
 
         if (which === KEY_UP || which === KEY_EN) {
           event.preventDefault();
-        }
-        else if (which === KEY_DW) {
+        } else if (which === KEY_DW) {
           event.preventDefault();
           if (!scope.showDropdown && scope.searchStr && scope.searchStr.length >= minlength) {
             initResults();
             scope.searching = true;
             searchTimerComplete(scope.searchStr);
           }
-        }
-        else if (which === KEY_ES) {
+        } else if (which === KEY_ES) {
           clearResults();
           scope.$apply(function() {
             inputField.val(scope.searchStr);
           });
-        }
-        else {
+        } else {
           if (minlength === 0 && !scope.searchStr) {
             return;
           }
@@ -298,7 +294,7 @@
 
       function handleOverrideSuggestions(event) {
         if (scope.overrideSuggestions &&
-            !(scope.selectedObject && scope.selectedObject.originalObject === scope.searchStr)) {
+          !(scope.selectedObject && scope.selectedObject.originalObject === scope.searchStr)) {
           if (event) {
             event.preventDefault();
           }
@@ -330,14 +326,14 @@
       function dropdownRowTop() {
         return dropdownRow().getBoundingClientRect().top -
           (dd.getBoundingClientRect().top +
-           parseInt(getComputedStyle(dd).paddingTop, 10));
+            parseInt(getComputedStyle(dd).paddingTop, 10));
       }
 
       function dropdownScrollTopTo(offset) {
         dd.scrollTop = dd.scrollTop + offset;
       }
 
-      function updateInputField(){
+      function updateInputField() {
         var current = scope.results[scope.currentIndex];
         if (scope.matchClass) {
           inputField.val(extractTitle(current.originalObject));
@@ -365,7 +361,7 @@
           event.preventDefault();
           if ((scope.currentIndex + 1) < scope.results.length && scope.showDropdown) {
             scope.$apply(function() {
-              scope.currentIndex ++;
+              scope.currentIndex++;
               updateInputField();
             });
 
@@ -380,7 +376,7 @@
           event.preventDefault();
           if (scope.currentIndex >= 1) {
             scope.$apply(function() {
-              scope.currentIndex --;
+              scope.currentIndex--;
               updateInputField();
             });
 
@@ -390,8 +386,7 @@
                 dropdownScrollTopTo(rowTop - 1);
               }
             }
-          }
-          else if (scope.currentIndex === 0) {
+          } else if (scope.currentIndex === 0) {
             scope.$apply(function() {
               scope.currentIndex = -1;
               inputField.val(scope.searchStr);
@@ -403,16 +398,14 @@
               // intentionally not sending event so that it does not
               // prevent default tab behavior
               handleOverrideSuggestions();
-            }
-            else {
+            } else {
               if (scope.currentIndex === -1) {
                 scope.currentIndex = 0;
               }
               scope.selectResult(scope.results[scope.currentIndex]);
               scope.$digest();
             }
-          }
-          else {
+          } else {
             // no results
             // intentionally not sending event so that it does not
             // prevent default tab behavior
@@ -449,11 +442,12 @@
         }
 
         // cancelled/aborted
-        if (status === 0 || status === -1) { return; }
+        if (status === 0 || status === -1) {
+          return;
+        }
         if (scope.remoteUrlErrorCallback) {
           scope.remoteUrlErrorCallback(errorRes, status, headers, config);
-        }
-        else {
+        } else {
           if (console && console.error) {
             console.error('http error');
           }
@@ -468,7 +462,7 @@
 
       function getRemoteResults(str) {
         var params = {},
-            url = scope.remoteUrl + encodeURIComponent(str);
+          url = scope.remoteUrl + encodeURIComponent(str);
         if (scope.remoteUrlRequestFormatter) {
           params = {params: scope.remoteUrlRequestFormatter(str)};
           url = scope.remoteUrl;
@@ -483,7 +477,9 @@
         $http.get(url, params)
           .then(httpSuccessCallbackGen(str))
           .catch(httpErrorCallback)
-          .finally(function(){httpCallInProgress=false;});
+          .finally(function() {
+            httpCallInProgress = false;
+          });
       }
 
       function getRemoteResultsWithCustomHandler(str) {
@@ -518,8 +514,8 @@
 
       function getLocalResults(str) {
         var i, match, s, value,
-            searchFields = scope.searchFields.split(','),
-            matches = [];
+          searchFields = scope.searchFields.split(','),
+          matches = [];
         if (typeof scope.parseInput() !== 'undefined') {
           str = scope.parseInput()(str);
         }
@@ -538,10 +534,12 @@
         return matches;
       }
 
-      function checkExactMatch(result, obj, str){
-        if (!str) { return false; }
-        for(var key in obj){
-          if(obj[key].toLowerCase() === str.toLowerCase()){
+      function checkExactMatch(result, obj, str) {
+        if (!str) {
+          return false;
+        }
+        for (var key in obj) {
+          if (obj[key].toLowerCase() === str.toLowerCase()) {
             scope.selectResult(result);
             return true;
           }
@@ -565,8 +563,7 @@
             scope.searching = false;
             processResults(matches, str);
           });
-        }
-        else if (scope.remoteApiHandler) {
+        } else if (scope.remoteApiHandler) {
           getRemoteResultsWithCustomHandler(str);
         } else {
           getRemoteResults(str);
@@ -612,8 +609,8 @@
         }
 
         if (scope.autoMatch && scope.results.length === 1 &&
-            checkExactMatch(scope.results[0],
-              {title: text, desc: description || ''}, scope.searchStr)) {
+          checkExactMatch(scope.results[0],
+            {title: text, desc: description || ''}, scope.searchStr)) {
           scope.showDropdown = false;
         } else if (scope.results.length === 0 && !displayNoResults) {
           scope.showDropdown = false;
@@ -626,12 +623,10 @@
         if (scope.localData) {
           scope.searching = false;
           processResults(scope.localData, '');
-        }
-        else if (scope.remoteApiHandler) {
+        } else if (scope.remoteApiHandler) {
           scope.searching = true;
           getRemoteResultsWithCustomHandler('');
-        }
-        else {
+        } else {
           scope.searching = true;
           getRemoteResults('');
         }
@@ -650,11 +645,10 @@
 
       scope.hideResults = function() {
         if (mousedownOn &&
-            (mousedownOn === scope.id + '_dropdown' ||
-             mousedownOn.indexOf('angucomplete') >= 0)) {
+          (mousedownOn === scope.id + '_dropdown' ||
+            mousedownOn.indexOf('angucomplete') >= 0)) {
           mousedownOn = null;
-        }
-        else {
+        } else {
           hideTimer = $timeout(function() {
             clearResults();
             scope.$apply(function() {
@@ -696,8 +690,7 @@
 
         if (scope.clearSelected) {
           scope.searchStr = null;
-        }
-        else {
+        } else {
           scope.searchStr = result.title;
         }
         callOrAssign(result);
@@ -708,8 +701,7 @@
         if (str.length < minlength) {
           cancelHttpRequest();
           clearResults();
-        }
-        else if (str.length === 0 && minlength === 0) {
+        } else if (str.length === 0 && minlength === 0) {
           showAll();
         }
 
@@ -749,8 +741,7 @@
         // check initial value, if given, set validitity to true
         if (scope.initialValue) {
           handleRequired(true);
-        }
-        else {
+        } else {
           handleRequired(false);
         }
       }

--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -57,9 +57,9 @@
       '        <img ng-if="result.image && result.image != \'\'" ng-src="{{result.image}}" class="angucomplete-image"/>' +
       '        <div ng-if="!result.image && result.image != \'\'" class="angucomplete-image-default"></div>' +
       '      </div>' +
-      '      <div class="angucomplete-title" ng-if="matchClass" ng-bind-html="result.title"></div>' +
+      '      <div class="angucomplete-title" ng-if="matchClass"><span ng-repeat="part in results.title" class="angucomplete-match" ng-class="{[matchClass]: part.match}">{{part.string}}</span></div>' +
       '      <div class="angucomplete-title" ng-if="!matchClass">{{ result.title }}</div>' +
-      '      <div ng-if="matchClass && result.description && result.description != \'\'" class="angucomplete-description" ng-bind-html="result.description"></div>' +
+      '      <div ng-if="matchClass && result.description && result.description != \'\'" class="angucomplete-description"><span ng-repeat="part in results.description" class="angucomplete-match" ng-class="{[matchClass]: part.match}">{{part.string}}</span></div>' +
       '      <div ng-if="!matchClass && result.description && result.description != \'\'" class="angucomplete-description">{{result.description}}</div>' +
       '    </div>' +
       '  </div>' +

--- a/bower.json
+++ b/bower.json
@@ -13,8 +13,8 @@
   ],
   "license": "MIT",
   "main": [
-      "./angucomplete-alt.js",
-      "./angucomplete-alt.css"
+    "./angucomplete-alt.js",
+    "./angucomplete-alt.css"
   ],
   "ignore": [
     "example",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,5 +1,7 @@
 // Karma configuration
 module.exports = function(config) {
+  'use strict';
+
   config.set({
 
     // base path, that will be used to resolve files and exclude
@@ -11,11 +13,10 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       // Dependencies
-      'bower_components/sizzle/dist/sizzle.js',
       'bower_components/jquery/dist/jquery.js',
       'bower_components/angular/angular.js',
       'bower_components/angular-mocks/angular-mocks.js',
-      
+
       // Source Code
       'angucomplete-alt.js',
 
@@ -52,7 +53,7 @@ module.exports = function(config) {
     // - Safari (only Mac)
     // - PhantomJS
     // - IE (only Windows)
-    browsers: ['Chrome'],
+    browsers: ['PhantomJS'],
 
     // If browser does not capture in given timeout [ms], kill it
     captureTimeout: 60000,


### PR DESCRIPTION
Instead of generating HTML inline and relying on ng-bind-html in the template, generate an array of strings which may or may not be matches.

This is a very minimal change. The rest of the library has not been refactored (in particular the case where highlighting is disabled is not covered as we don't use it), and the internal template has not been modified as we use our own.

Requires a corresponding change to ck-autocomplete (coming soon to a repo near you).